### PR TITLE
Catch context promise error

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,9 @@ var AudioStream = function(media, options) {
 			processor.disconnect();
 			gain.disconnect();
 			source.disconnect();
-			if(!options.context) context.close();
+			if(!options.context) context.close().catch(function(e) {
+				debug(e);
+			});
 		};
 
 		self.on('end', function() {


### PR DESCRIPTION
When destroying an audio-stream, this context was throwing an uncaught dom exception in chrome/electron:

<img width="652" alt="screen shot 2017-04-17 at 2 31 29 pm" src="https://cloud.githubusercontent.com/assets/166301/25105693/96c9ee2a-237a-11e7-8cc6-f67a9981c65a.png">

This patch just catches and and debug's it since it doesn't appear to be be causing any harm.